### PR TITLE
[HOPSWORKS-980] fix pandas/numpy naming conflicts

### DIFF
--- a/notebooks/featurestore/petastorm/PetastormMNIST_CreateDataset.ipynb
+++ b/notebooks/featurestore/petastorm/PetastormMNIST_CreateDataset.ipynb
@@ -206,11 +206,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from hops import numpy as hops_numpy\n",
+    "from hops import numpy_helper as hops_numpy\n",
     "hops_numpy.save(\"mnist/train_img_val.npy\", train_images[0:2])\n",
     "hops_numpy.save(\"mnist/train_lbl_val.npy\", train_labels[0:2])\n",
     "hops_numpy.save(\"mnist/test_img_val.npy\", test_images[0:2])\n",
@@ -233,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +242,7 @@
     "from hops import hdfs\n",
     "import numpy as np\n",
     "from tempfile import TemporaryFile\n",
-    "from hops import numpy as hops_numpy\n",
+    "from hops import numpy_helper as hops_numpy\n",
     "\n",
     "def plot_train_example(example_num):\n",
     "    \"\"\"\n",

--- a/tensorflow/notebooks/numpy/numpy-hdfs.ipynb
+++ b/tensorflow/notebooks/numpy/numpy-hdfs.ipynb
@@ -10,38 +10,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "from hops import hdfs\n",
-    "from hops import numpy\n",
+    "from hops import numpy_helper as numpy\n",
     "data = numpy.load(\"TestJob/data/numpy/C_test.npy\")\n",
     "\n",
     "data.shape\n",
     "\n",
     "numpy.save(\"Resources/project-relative-path.npy\", data)\n",
-    "numpy.save(hdfs.project_path() + \"/Resources/full-path.npy\", data)\n"
+    "numpy.save(hdfs.project_path() + \"/Resources/full-path.npy\", data)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python-demo_deep_learning_admin000__meb10000",
+   "display_name": "python-demo_featurestore_admin000__meb10000",
    "language": "python",
-   "name": "python-demo_deep_learning_admin000__meb10000"
+   "name": "python-demo_featurestore_admin000__meb10000"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
   }
  },
  "nbformat": 4,

--- a/tensorflow/notebooks/pandas/pandas-hdfs.ipynb
+++ b/tensorflow/notebooks/pandas/pandas-hdfs.ipynb
@@ -10,12 +10,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
     "from hops import hdfs\n",
-    "from hops import pandas\n",
+    "from hops import pandas_helper as pandas\n",
     "import pandas as pd\n",
     "features = [\"Age\", \"Workclass\", \"fnlwgt\", \"Education\", \"Education-Num\", \"Marital Status\",\n",
     "            \"Occupation\", \"Relationship\", \"Race\", \"Sex\", \"Capital Gain\", \"Capital Loss\",\n",
@@ -31,21 +31,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python-demo_deep_learning_admin000__meb10000",
+   "display_name": "python-demo_featurestore_admin000__meb10000",
    "language": "python",
-   "name": "python-demo_deep_learning_admin000__meb10000"
+   "name": "python-demo_featurestore_admin000__meb10000"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Update notebooks to import new module names for "numpy_helper" and "pandas_helper" inside hops instead of "numpy" and "hops".