### PR TITLE
[HOPSWORKS-1982] Adapt feature store tour to HSFS Statistics

### DIFF
--- a/featurestore_tour/pom.xml
+++ b/featurestore_tour/pom.xml
@@ -33,12 +33,6 @@
       <artifactId>scallop_${scala.base}</artifactId>
       <version>3.3.0</version>
     </dependency>
-    <dependency>
-      <groupId>com.logicalclocks</groupId>
-      <artifactId>hsfs</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/featurestore_tour/pom.xml
+++ b/featurestore_tour/pom.xml
@@ -33,6 +33,12 @@
       <artifactId>scallop_${scala.base}</artifactId>
       <version>3.3.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.logicalclocks</groupId>
+      <artifactId>hsfs</artifactId>
+      <version>2.0.0-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/notebooks/featurestore/FeaturestoreTourScala.ipynb
+++ b/notebooks/featurestore/FeaturestoreTourScala.ipynb
@@ -619,7 +619,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Creating New Feature Groups\n"
+    "### Creating New Feature Groups\n",
+    "\n",
+    "### <span style=\"color:red\">Deprecated: Statistics have been deprecated in `hops-util`. Creating feature groups will not compute statistics for the created group. Please switch to use the new `hsfs` Scala/Java client.</span>\n"
    ]
   },
   {
@@ -1949,6 +1951,8 @@
    "source": [
     "## Feature Group Statistics\n",
     "\n",
+    "### <span style=\"color:red\">Deprecated: Statistics have been deprecated in `hops-util`. Creating feature groups will not compute statistics for the created group. Please switch to use the new `hsfs` Scala/Java client.</span>\n",
+    "\n",
     "Statistics about a featuregroup can be useful in the stage of feature engineering and when deciding which features to use for training. If statistics have been computed for a feature group, it can be viewed in the Hopsworks Feature Registry UI. \n",
     "\n",
     "This is particularly useful within large organizations where data scientists from different teams can re-use and explore new features by browsing features in the feature store and analyzing the statistics.\n",
@@ -2051,7 +2055,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Create New Training Dataset"
+    "### Create New Training Dataset\n",
+    "\n",
+    "### <span style=\"color:red\">Deprecated: Statistics have been deprecated in `hops-util`. Creating training datasets will not compute statistics for the created dataset. Please switch to use the new `hsfs` Scala/Java client.</span>"
    ]
   },
   {
@@ -2467,6 +2473,8 @@
    "metadata": {},
    "source": [
     "### Update Training Dataset Stats\n",
+    "\n",
+    "### <span style=\"color:red\">Deprecated: Statistics have been deprecated in `hops-util`. Creating training datasets will not compute statistics for the created dataset. Please switch to use the new `hsfs` Scala/Java client.</span>\n",
     "\n",
     "The API is similar to the one for updating the stats of a feature group:"
    ]

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.logicalclocks</groupId>
+      <artifactId>hsfs</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>io.hops</groupId>
       <artifactId>hadoop-client</artifactId>
       <version>${hops.version}</version>


### PR DESCRIPTION
this PR partitially migrates the feature store tour to the new HSFS client.

This is not yet possible for HUdi and On demand featuregroups.

tour runs in 8 minutes on standard 1 node Vagrant VM.