### PR TITLE
[api_key_jobs-client] Export API key as environment variable

### DIFF
--- a/jobs-client/spark/jobs_spark_client.py
+++ b/jobs-client/spark/jobs_spark_client.py
@@ -25,6 +25,9 @@ app_file = args.main
 app_folder = args.workspace
 dependency = ntpath.basename(app_folder)
 
+if not os.path.isfile(args.apikey):
+    os.environ['API_KEY'] = args.apikey
+
 with open('job_config.json') as json_file:
     data = json_file.read()
 


### PR DESCRIPTION
If the API key parameter is the actual key, it must be exported as an environment variable - it is needed by hops-util-py. If it's a file containing the API key, then hops-util-py will read it up from there.